### PR TITLE
Improved and Corrected Caching Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Available color names and hex codes are listed on [here](https://github.com/jong
 
 ## Note
 
-GitHub caches badge data in 604800 seconds(=7 days). To update, try: `curl -X PURGE "https://camo.githubusercontent.com/..."` (it's badge image link)
+GitHub caches badge data in 604800 seconds(=7 days). 
+
+The server will send headers to prevent this and set the cache time to 3666 seconds ,
+to have purge the cache before, try: `curl -X PURGE "https://camo.githubusercontent.com/..."` (it's badge image link)
+in the `server.py` is documented what leads to "no-caching" at all with github camo cache
 
 [1]: <https://ghcr-badge.deta.dev/eggplants/ghcr-badge/tags?trim=major>
 [2]: <https://ghcr-badge.deta.dev/eggplants/ghcr-badge/latest_tag?trim=major&label=latest>

--- a/ghcr_badge/server.py
+++ b/ghcr_badge/server.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from os import environ
 from typing import TYPE_CHECKING
+from datetime import datetime
+from datetime import timedelta
+
 
 from flask import Flask, jsonify, make_response, request
 
@@ -34,7 +37,23 @@ def return_svg(svg: str) -> Response:
         svg,
     )
     res.mimetype = "image/svg+xml"
-    res.headers["Cache-Control"] = "max-age=3600, s-maxage=3600"
+    """Expiry
+    Header Formats: Expires is "-1" OR a HTTP time stamp e.g. "Expires: Wed, 21 Oct 2015 07:28:00 GMT"
+    expiredate=( datetime.now() + timedelta(hours=1, minutes=1,seconds=6) ).strftime('%a, %d %b %Y %H:%M:%S GMT')
+    print(f"CACHE EXPIRY will be {expiredate}.")
+    For NO cache at all :
+    Cache-Control: no-cache,max-age=0,no-store,s-maxage=0
+    Expires: -1
+    Pragma: no-cache
+    
+    Using 3666 Seconds below
+    """
+    res.headers["Cache-Control"] = "max-age=3666, s-maxage=3666,no-store,proxy-revalidate"
+    res.headers["Pragma"] = "no-cache"
+    res.headers["Expires"] = ( datetime.now() + timedelta(hours=1, minutes=1,seconds=6) ).strftime('%a, %d %b %Y %H:%M:%S GMT')
+
+
+
     return res
 
 


### PR DESCRIPTION
## Changes

To improve Camo caching , 2 headers were added to the output

* `Expires` (HTTP-timestamp , set to 1hr 1m 1 s)
* `Pragma`

Parts that were changed:
* `cache-control` header was adjusted, `,no-store,proxy-revalidate` added to the value
* comment on which headers lead to no caching was added to `server.py`
* `README.md` was updated ( but `curl -X PURGE` hint is still there )

## Result 

```python
    res.headers["Cache-Control"] = "max-age=3666, s-maxage=3666,no-store,proxy-revalidate"
    res.headers["Pragma"] = "no-cache"
    res.headers["Expires"] = ( datetime.now() + timedelta(hours=1, minutes=1,seconds=6) ).strftime('%a, %d %b %Y %H:%M:%S GMT')
```